### PR TITLE
refactor(ui): Dynamically generate upgrade UI from data

### DIFF
--- a/public/pages/upgrades.html
+++ b/public/pages/upgrades.html
@@ -1,15 +1,5 @@
 <section id="upgrades_section" class="page">
   <div id="upgrades_content_wrapper">
-    <h2>General Upgrades</h2>
-    <div id="other_upgrades" class="pixel-panel upgrade-group"></div>
-
-    <h2>Cooling Upgrades</h2>
-    <div id="vent_upgrades" class="pixel-panel upgrade-group"></div>
-    <div id="exchanger_upgrades" class="pixel-panel upgrade-group"></div>
-
-    <h2>Cell Upgrades</h2>
-    <div id="cell_power_upgrades" class="pixel-panel upgrade-group"></div>
-    <div id="cell_tick_upgrades" class="pixel-panel upgrade-group"></div>
-    <div id="cell_perpetual_upgrades" class="pixel-panel upgrade-group"></div>
+    <!-- Upgrade categories will be dynamically generated here -->
   </div>
 </section>

--- a/src/core/stateManager.js
+++ b/src/core/stateManager.js
@@ -147,15 +147,10 @@ export class StateManager {
     }
   }
   handleUpgradeAdded(game, upgrade_obj, container) {
-    if (!container) {
-        // Fallback for safety, but should not be needed with the new approach
-        const locationKey = upgrade_obj.upgrade.type + "_upgrades";
-        container = document.getElementById(locationKey);
-        if (!container) {
-            console.error(`[StateManager] Container not found for upgrade type '${upgrade_obj.upgrade.type}' and no container was provided.`);
-            return;
-        }
-    }
+      if (!container) {
+          console.error(`[StateManager] Container not found for upgrade type '${upgrade_obj.upgrade.type}' and no container was provided.`);
+          return;
+      }
     const upgradeEl = upgrade_obj.createElement();
     upgradeEl.upgrade_object = upgrade_obj;
     container.appendChild(upgradeEl);

--- a/src/core/stateManager.js
+++ b/src/core/stateManager.js
@@ -146,21 +146,16 @@ export class StateManager {
       container.appendChild(part_el);
     }
   }
-  handleUpgradeAdded(game, upgrade_obj) {
-    const normalizeKey = (key) => {
-      const map = {
-        cell_power: "cell_power_upgrades",
-        cell_tick: "cell_tick_upgrades",
-        cell_perpetual: "cell_perpetual_upgrades",
-        exchangers: "exchanger_upgrades",
-        vents: "vent_upgrades",
-        other: "other_upgrades",
-      };
-      return map[key] || key;
-    };
-    let locationKey = normalizeKey(upgrade_obj.upgrade.type);
-    const container = document.getElementById(locationKey);
-    if (!container) return;
+  handleUpgradeAdded(game, upgrade_obj, container) {
+    if (!container) {
+        // Fallback for safety, but should not be needed with the new approach
+        const locationKey = upgrade_obj.upgrade.type + "_upgrades";
+        container = document.getElementById(locationKey);
+        if (!container) {
+            console.error(`[StateManager] Container not found for upgrade type '${upgrade_obj.upgrade.type}' and no container was provided.`);
+            return;
+        }
+    }
     const upgradeEl = upgrade_obj.createElement();
     upgradeEl.upgrade_object = upgrade_obj;
     container.appendChild(upgradeEl);

--- a/src/core/upgradeset.js
+++ b/src/core/upgradeset.js
@@ -163,10 +163,10 @@ export class UpgradeSet {
 
   _formatUpgradeType(type) {
     // Example: 'cell_power_upgrades' -> 'Cell Power Upgrades'
-    return type
-        .replace(/_/g, ' ')
-        .replace('upgrades', '')
-        .trim()
+      return type
+          .replace(/_upgrades$/, '')
+          .replace(/_/g, ' ')
+          .trim()
         .replace(/\b\w/g, char => char.toUpperCase());
   }
 


### PR DESCRIPTION
### **User description**
Refactored the upgrade screen UI generation to be fully dynamic, adhering to the UI/UX specification (FR-UI-UPGRADES-2).

- Removed hardcoded upgrade category containers from upgrades.html.
- Modified UpgradeSet to group upgrades by type and dynamically create category headers and containers.
- Simplified StateManager's handleUpgradeAdded method to accept a container element directly, decoupling it from the DOM structure.

This change ensures that new upgrade categories defined in upgrade_list.json will be automatically rendered in the UI without requiring any changes to the HTML or component code.


___

### **PR Type**
Enhancement


___

### **Description**
- Dynamically generate upgrade UI categories from data

- Remove hardcoded HTML upgrade containers

- Refactor StateManager to accept container elements directly

- Group upgrades by type with automatic header creation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["upgrade_list.json"] --> B["UpgradeSet grouping"]
  B --> C["Dynamic container creation"]
  C --> D["StateManager rendering"]
  D --> E["Generated upgrade UI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stateManager.js</strong><dd><code>Refactor upgrade rendering to accept containers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/stateManager.js

<ul><li>Simplified <code>handleUpgradeAdded</code> to accept container parameter<br> <li> Removed hardcoded category-to-container mapping logic<br> <li> Added fallback error handling for missing containers</ul>


</details>


  </td>
  <td><a href="https://github.com/jdial1/reactor-revival/pull/4/files#diff-2976766ef6c132f6226c842c8d554789deca1c05c069b3aeaa71d94014568af5">+10/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upgradeset.js</strong><dd><code>Dynamic upgrade category generation and rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/core/upgradeset.js

<ul><li>Added dynamic grouping of upgrades by type<br> <li> Implemented automatic header and container creation<br> <li> Added <code>_formatUpgradeType</code> helper for display names<br> <li> Modified filtering logic for experimental upgrades</ul>


</details>


  </td>
  <td><a href="https://github.com/jdial1/reactor-revival/pull/4/files#diff-e9977d4ac3a2071bc4da182689e89afa39fb0ba2f97ddfa5dd866a162f5b68d4">+56/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upgrades.html</strong><dd><code>Remove hardcoded upgrade HTML structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

public/pages/upgrades.html

<ul><li>Removed all hardcoded upgrade category headers<br> <li> Removed all hardcoded upgrade container divs<br> <li> Replaced with placeholder comment for dynamic content</ul>


</details>


  </td>
  <td><a href="https://github.com/jdial1/reactor-revival/pull/4/files#diff-fb6f487cb1de3c0d7a693d9f5b144e44393d452faf5132f68f337cce60ec773a">+1/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

