### PR TITLE
🎨 Palette: Add purchase feedback animation to upgrades

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -202,6 +202,22 @@ body {
   transform-origin: center center;
 }
 
+@keyframes upgrade-purchase-glow {
+  0% {
+    box-shadow: 0 0 0 0 rgb(143 214 148 / 0.8), 4px 4px 0 rgb(0 0 0 / 40%);
+    filter: brightness(1.5);
+  }
+  100% {
+    box-shadow: 0 0 20px 10px rgb(143 214 148 / 0), 4px 4px 0 rgb(0 0 0 / 40%);
+    filter: brightness(1);
+  }
+}
+
+.upgrade-purchase-success {
+  animation: upgrade-purchase-glow 0.4s ease-out;
+  z-index: 10;
+}
+
 /* Button Press Effect */
 .pixel-btn:active,
 .splash-btn:active,

--- a/public/src/core/upgradeset.js
+++ b/public/src/core/upgradeset.js
@@ -219,6 +219,14 @@ export class UpgradeSet {
 
     if (purchased) {
       upgrade.setLevel(upgrade.level + 1);
+
+      // Visual feedback: trigger purchase success animation
+      if (upgrade.$el) {
+        upgrade.$el.classList.remove("upgrade-purchase-success");
+        void upgrade.$el.offsetWidth; // Force reflow to re-trigger animation
+        upgrade.$el.classList.add("upgrade-purchase-success");
+      }
+
       this.game.debugHistory.add('upgrades', 'Upgrade purchased', { id: upgradeId, level: upgrade.level });
       if (upgrade.upgrade.type === "experimental_parts") {
         this.game.epart_onclick(upgrade);


### PR DESCRIPTION
### **User description**
Implemented a visible micro-UX improvement by adding a "purchase success" animation to upgrade cards.

Key changes:
1.  **CSS Animation**: Added `@keyframes upgrade-purchase-glow` and `.upgrade-purchase-success` class in `public/css/main.css`. The animation features a brightness boost and a green outer glow.
2.  **JS Trigger**: Modified `UpgradeSet.purchaseUpgrade` in `public/src/core/upgradeset.js` to apply the animation class to the purchased upgrade's DOM element. Used the `offsetWidth` reflow trick to ensure the animation can be re-triggered for rapid successive purchases.

Verification:
-   Verified with Playwright screenshots that the glow is clearly visible during the purchase action.
-   Ran unit tests (`upgradeset.test.js`) and UI tests (`upgrade_button.test.js`) to ensure core functionality remains intact.
-   Ensured no unrelated library or lockfile changes were included.

---
*PR created automatically by Jules for task [16673958449367133129](https://jules.google.com/task/16673958449367133129) started by @jdial1*


___

### **PR Type**
Enhancement


___

### **Description**
- Added green glow and brightness animation for upgrade purchases

- Animation triggers on successful upgrade purchase with reflow trick

- Provides immediate visual feedback to player actions

- Enhances core gameplay loop with micro-UX improvement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Player purchases upgrade"] --> B["setLevel incremented"]
  B --> C["Remove animation class"]
  C --> D["Force reflow via offsetWidth"]
  D --> E["Add animation class"]
  E --> F["Green glow + brightness flash"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upgradeset.js</strong><dd><code>Trigger purchase animation on upgrade level increase</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

public/src/core/upgradeset.js

<ul><li>Added visual feedback logic in <code>purchaseUpgrade</code> method after level <br>increment<br> <li> Removes and re-adds <code>upgrade-purchase-success</code> class to trigger <br>animation<br> <li> Uses <code>offsetWidth</code> reflow trick to allow animation re-triggering on <br>rapid purchases<br> <li> Includes null check for <code>upgrade.$el</code> DOM element</ul>


</details>


  </td>
  <td><a href="https://github.com/jdial1/reactor-revival/pull/70/files#diff-1af622894c48fc744025a8b4145e496be93a2a9616dec9ff89849ed8bb46440f">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.css</strong><dd><code>Define upgrade purchase glow animation keyframes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

public/css/main.css

<ul><li>Added <code>@keyframes upgrade-purchase-glow</code> animation with green glow <br>effect<br> <li> Animation transitions from bright (1.5x) to normal brightness over <br>0.4s<br> <li> Box-shadow expands from tight to diffuse green glow during animation<br> <li> Added <code>.upgrade-purchase-success</code> class with z-index elevation and <br>animation binding</ul>


</details>


  </td>
  <td><a href="https://github.com/jdial1/reactor-revival/pull/70/files#diff-38694555b55d4f5e7a68d7d8435daa342e64a17090b9d59bcdbc43b812ea320f">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

